### PR TITLE
Fix "Comparisons of text column conditions are not allowed. Please use sql_compare_text() in your query" error when trigger function is called.

### DIFF
--- a/classes/event_trigger.php
+++ b/classes/event_trigger.php
@@ -91,7 +91,7 @@ class event_trigger
                     //save the last data
                     if(!in_array($event_data['eventname'],constants::SAMPLE_EVENTS)) {
                         if ($DB->record_exists_select(constants::SAMPLE_TABLE, sprintf("%s = :event", $DB->sql_compare_text('event')), array('event' => $event_data['eventname']))) {
-                            $DB->delete_records(constants::SAMPLE_TABLE, array('event' => $event_data['eventname']));
+                            $DB->delete_records_select(constants::SAMPLE_TABLE, sprintf("%s = :event", $DB->sql_compare_text('event')), array('event' => $event_data['eventname']));
                         }
                         $DB->insert_record(constants::SAMPLE_TABLE, array('event' => $event_data['eventname'], 'eventdata' => json_encode($event_data)));
                     }
@@ -114,7 +114,7 @@ class event_trigger
         //get the event data.
         $event_data = $event->get_data();
         if ($DB->record_exists_select(constants::SAMPLE_TABLE, sprintf("%s = :event", $DB->sql_compare_text('event')), array('event' => $event_data['eventname']))) {
-            $DB->delete_records(constants::SAMPLE_TABLE, array('event' => $event_data['eventname']));
+            $DB->delete_records_select(constants::SAMPLE_TABLE, sprintf("%s = :event", $DB->sql_compare_text('event')), array('event' => $event_data['eventname']));
         }
         $DB->insert_record(constants::SAMPLE_TABLE, array('event' => $event_data['eventname'], 'eventdata' => json_encode($event_data)));
 

--- a/classes/event_trigger.php
+++ b/classes/event_trigger.php
@@ -90,7 +90,7 @@ class event_trigger
 
                     //save the last data
                     if(!in_array($event_data['eventname'],constants::SAMPLE_EVENTS)) {
-                        if ($DB->record_exists(constants::SAMPLE_TABLE, array('event' => $event_data['eventname']))) {
+                        if ($DB->record_exists_select(constants::SAMPLE_TABLE, sprintf("%s = :event", $DB->sql_compare_text('event')), array('event' => $event_data['eventname']))) {
                             $DB->delete_records(constants::SAMPLE_TABLE, array('event' => $event_data['eventname']));
                         }
                         $DB->insert_record(constants::SAMPLE_TABLE, array('event' => $event_data['eventname'], 'eventdata' => json_encode($event_data)));
@@ -113,7 +113,7 @@ class event_trigger
         global $DB;
         //get the event data.
         $event_data = $event->get_data();
-        if ($DB->record_exists(constants::SAMPLE_TABLE, array('event' => $event_data['eventname']))) {
+        if ($DB->record_exists_select(constants::SAMPLE_TABLE, sprintf("%s = :event", $DB->sql_compare_text('event')), array('event' => $event_data['eventname']))) {
             $DB->delete_records(constants::SAMPLE_TABLE, array('event' => $event_data['eventname']));
         }
         $DB->insert_record(constants::SAMPLE_TABLE, array('event' => $event_data['eventname'], 'eventdata' => json_encode($event_data)));


### PR DESCRIPTION
The Comparisons of text column conditions are not allowed. Please use sql_compare_text() in your query error is returned when debugging is enabled in Moodle 3.8.5+, caused by the record_exists usage which doesn't use sql_compare_text. This PR changes the implementation of record_exists to record_exists_select and using sql_compare_text as well.